### PR TITLE
Hook on like

### DIFF
--- a/includes/like-functions.php
+++ b/includes/like-functions.php
@@ -189,6 +189,9 @@ function bp_like_add_user_like( $item_id, $type ) {
 
     echo bp_like_get_text( 'unlike' );
     echo ' <span>' . ( $liked_count ? $liked_count : '0' ) . '</span>';
+
+    // Add hook on new like
+    do_action('bp_like_added', $item_id, $user_id);
 }
 
 /**


### PR DESCRIPTION
I've added a hook that fires when a new like is registered. This enables us to do stuff when an item is liked.

I see in the code that you are preparing to add notifications and that you have added hooks to the different activity types. However, it would be nice to also have a general hook that fires no matter what the type is.

This hook also makes it possible to add support for likes on custom post types and not only activity updates and blog posts.

I have implemented like notifications for all post types using this hook and I thought I might issue a PR to see if you would consider adding it to the plugin.
